### PR TITLE
Fix slug sanitization and case-sensitive include

### DIFF
--- a/src/headless-api/article.php
+++ b/src/headless-api/article.php
@@ -90,7 +90,7 @@ class ArticleAPI {
      * )
      */
     public function getArticlesBySlug($slug) {
-        $id = $this->db->escape_string($slug);
+        $slug = $this->db->escape_string($slug);
         $result = $this->db->query("SELECT * FROM " . $this->config->dbprefix . "content WHERE alias = '$slug'");
         $articles = [];
 

--- a/src/headless-api/menu.php
+++ b/src/headless-api/menu.php
@@ -1,5 +1,5 @@
 <?php
-require_once 'Database.php';
+require_once 'database.php';
 
 /**
  * @OA\Info(title="Joomla Headless API", version="1.0.0")


### PR DESCRIPTION
## Summary
- sanitize slug variable correctly in `ArticleAPI`
- fix case-sensitive filename for database include in `MenuAPI`

## Testing
- `php -l src/headless-api/article.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684740e8d508832db6a6adc5cdfe930d