### PR TITLE
Add PHPUnit test setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,12 @@ docker-compose up -d
 
 podman build --security-opt seccomp=unconfined -t apache-php .
 podman run --security-opt seccomp=unconfined -v $(pwd):/var/www/html -p 8080:80 apache-php
+
+### Running tests
+
+Install the Composer dependencies and execute PHPUnit:
+
+```bash
+composer install
+vendor/bin/phpunit
+```

--- a/composer.json
+++ b/composer.json
@@ -15,5 +15,8 @@
     "require": {
         "zircote/swagger-php": "^5.0",
         "league/html-to-markdown": "^5.1"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.5"
     }
 }

--- a/tests/ArticleApiTest.php
+++ b/tests/ArticleApiTest.php
@@ -1,0 +1,42 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+class ArticleApiTest extends TestCase
+{
+    public function testGetArticlesBySlugUsesSanitizedInput()
+    {
+        $mockDb = new class {
+            public $escapedInput;
+            public $queryString;
+            public function escape_string($string) {
+                $this->escapedInput = $string;
+                return 'safe_' . $string;
+            }
+            public function query($sql) {
+                $this->queryString = $sql;
+                return new class {
+                    public function fetch_assoc() { return null; }
+                };
+            }
+        };
+
+        $api = new ArticleAPI();
+
+        $ref = new ReflectionClass($api);
+        $propDb = $ref->getProperty('db');
+        $propDb->setAccessible(true);
+        $propDb->setValue($api, $mockDb);
+
+        $propConfig = $ref->getProperty('config');
+        $propConfig->setAccessible(true);
+        $propConfig->setValue($api, (object)['dbprefix' => 'jos_']);
+
+        $api->getArticlesBySlug('example');
+
+        $this->assertEquals('example', $mockDb->escapedInput);
+        $this->assertSame(
+            "SELECT * FROM jos_content WHERE alias = 'safe_example'",
+            $mockDb->queryString
+        );
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,3 @@
+<?php
+require __DIR__ . '/../vendor/autoload.php';
+require_once __DIR__ . '/../src/headless-api/article.php';


### PR DESCRIPTION
## Summary
- add `phpunit/phpunit` as a dev dependency
- create PHPUnit bootstrap and a test verifying slug sanitization
- document how to run the test suite

## Testing
- `vendor/bin/phpunit --bootstrap tests/bootstrap.php tests/ArticleApiTest.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684741be87cc832d8427a05bff18f04a