### PR TITLE
Fix categories endpoint Swagger comments

### DIFF
--- a/src/headless-api/category.php
+++ b/src/headless-api/category.php
@@ -27,11 +27,11 @@ class CategoryAPI {
 
     /**
      * @OA\Get(
-     *     path="/categories/{id}",
-     *     summary="Get category by ID",
+     *     path="/categories",
+     *     summary="Get all categories",
      *     @OA\Response(
      *         response=200,
-     *         description="List of categorie",
+     *         description="List of categories",
      *         @OA\JsonContent(ref="#/components/schemas/Category")
      *     )
      * )


### PR DESCRIPTION
## Summary
- update Swagger docs in `category.php` to use `/categories` path
- adjust summary and description to indicate the endpoint returns all categories

## Testing
- `./vendor/bin/phpunit tests` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68474329b5d0832da680e171a65ecb23