### PR TITLE
Fix Dockerfile for composer availability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,13 @@ RUN apt-get update && apt-get install -y \
     unzip \
     git \
     curl \
-    && docker-php-ext-install pdo_mysql mbstring exif pcntl bcmath gd mysqli
+    && docker-php-ext-install pdo_mysql mbstring exif pcntl bcmath gd mysqli && \
+    curl -sS https://getcomposer.org/installer -o /tmp/composer-setup.php && \
+    HASH="$(curl -sS https://composer.github.io/installer.sig)" && \
+    php -r "if (hash_file('SHA384', '/tmp/composer-setup.php') === '$HASH') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;" && \
+    php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer && \
+    rm -f /tmp/composer-setup.php && \
+    chmod +x /usr/local/bin/composer
 
 # Enable Apache mod_rewrite
 RUN a2enmod rewrite

--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ Include the Composer autoloader with: require 'vendor/autoload.php';
 ### Update the swagger file
 ```bash
 podman build --security-opt seccomp=unconfined -t php-swagger .
-podman run --security-opt seccomp=unconfined -v $(pwd):/app php-swagger
-
-podman run --security-opt seccomp=unconfined -v $(pwd):/app -ti php-swagger "vendor/bin/openapi --output /app/openapi.yaml /app/src"
+podman run --security-opt seccomp=unconfined -v $(pwd):/app -ti php-swagger bash -c "composer install && ./vendor/bin/openapi --output /app/openapi.yaml /app/src/headless-api/"
 ```
 
 ./vendor/bin/openapi --output openapi.yaml ./src


### PR DESCRIPTION
## Summary
- install Composer in the main Dockerfile
- document running composer install together with the openapi call

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: no such file)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684744c0da64832db301311a87d5de24