### PR TITLE
Add installation guide and packaging Dockerfile

### DIFF
--- a/install.md
+++ b/install.md
@@ -1,0 +1,35 @@
+# Installation
+
+This repository contains a standalone set of PHP scripts that expose a headless API for Joomla. The code is not packaged as a Joomla extension, so you simply place the files alongside your Joomla site.
+
+Two common approaches are described below.
+
+## 1. Local Composer
+
+If PHP and Composer are available on your machine:
+
+```bash
+# clone the repository
+cd /path/to/your/project
+git clone <repository-url> headless-api
+cd headless-api
+
+# install dependencies without development packages
+composer install --no-dev --optimize-autoloader
+```
+
+Copy `src/` (or the generated `vendor/` and API files) to a directory that is **outside** the Joomla core so upgrades do not overwrite it. Update `src/configuration.php` or `src/headless-api/database.php` to reference your site's database credentials or existing `configuration.php`.
+
+## 2. Podman / Docker
+
+If you prefer not to install PHP locally you can build a container that performs the installation. The `tools/Dockerfile.distribution` image installs the dependencies and bundles the API into a single archive.
+
+```bash
+cd tools
+podman build -f Dockerfile.distribution -t joomla-headless-api-dist .
+podman run --rm -v $(pwd)/..:/app joomla-headless-api-dist
+```
+
+The container produces `joomla-headless-api.zip` inside the project root. Upload the archive next to your Joomla installation and extract it. Point your web server (or a Joomla menu item) to the PHP files in this directory.
+
+You can use `docker` in place of `podman` if desired.

--- a/tools/Dockerfile.distribution
+++ b/tools/Dockerfile.distribution
@@ -1,0 +1,23 @@
+# Build image to prepare a distributable archive
+FROM php:8.4-cli
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y \
+    zip \
+    unzip \
+    git && rm -rf /var/lib/apt/lists/*
+
+# Install Composer
+RUN curl -sS https://getcomposer.org/installer -o /tmp/composer-setup.php && \
+    HASH="$(curl -sS https://composer.github.io/installer.sig)" && \
+    php -r "if (hash_file('SHA384', '/tmp/composer-setup.php') === '$HASH') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('/tmp/composer-setup.php'); } echo PHP_EOL;" && \
+    php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer && \
+    rm -f /tmp/composer-setup.php
+
+COPY .. /app
+
+RUN composer install --no-dev --optimize-autoloader && \
+    zip -r joomla-headless-api.zip src vendor openapi.yaml
+
+CMD ["/bin/sh"]


### PR DESCRIPTION
## Summary
- document two installation methods in `install.md`
- add `tools/Dockerfile.distribution` for creating a zipped distribution

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68474f87810c832da45355796e99d802