### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Build Distribution
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          tools: composer
+      - name: Install dependencies
+        run: composer install --no-dev --optimize-autoloader
+      - name: Create archive
+        run: zip -r joomla-headless-api.zip src vendor openapi.yaml
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: joomla-headless-api
+          path: joomla-headless-api.zip
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: joomla-headless-api.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- build a distribution ZIP on push tag or manual run
- upload the file and attach to a GitHub release

## Testing
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68475a437208832d82040e50916a9d91