### PR TITLE
Restructure endpoints under resource directories

### DIFF
--- a/src/HeadlessApi/ArticleAPI.php
+++ b/src/HeadlessApi/ArticleAPI.php
@@ -1,7 +1,7 @@
 <?php
 namespace Cr8\JoomlaHeadlessApi\HeadlessApi;
 
-require_once 'database.php';
+require_once __DIR__ . '/database.php';
 use OpenApi\Annotations as OA;
 
 /**
@@ -102,18 +102,6 @@ class ArticleAPI {
         }
 
         return $articles;
-    }
-}
-
-if ($_SERVER['REQUEST_METHOD'] === 'GET') {
-    $api = new ArticleAPI();
-
-    if (isset($_GET['category'])) {
-        echo json_encode($api->getArticlesByCategory($_GET['category']));
-    } elseif (isset($_GET['id'])) {
-        echo json_encode($api->getArticlesById($_GET['id']));
-    } elseif (isset($_GET['slug'])) {
-        echo json_encode($api->getArticlesBySlug($_GET['slug']));
     }
 }
 

--- a/src/HeadlessApi/CategoryAPI.php
+++ b/src/HeadlessApi/CategoryAPI.php
@@ -1,8 +1,8 @@
 <?php
 namespace Cr8\JoomlaHeadlessApi\HeadlessApi;
 
-require_once 'database.php';
-require_once '../configuration.php';
+require_once __DIR__ . '/database.php';
+require_once __DIR__ . '/../configuration.php';
 use OpenApi\Annotations as OA;
 
 /**
@@ -47,16 +47,6 @@ class CategoryAPI {
         }
 
         return $categories;
-    }
-}
-
-if ($_SERVER['REQUEST_METHOD'] === 'GET') {
-    $api = new CategoryAPI();
-    $json = json_encode($api->getCategories(), JSON_FORCE_OBJECT | JSON_PRETTY_PRINT);
-    if ($json === false) {
-        echo 'JSON encoding error: ' . json_last_error_msg();
-    } else {
-        echo $json;
     }
 }
 

--- a/src/HeadlessApi/MenuAPI.php
+++ b/src/HeadlessApi/MenuAPI.php
@@ -1,7 +1,7 @@
 <?php
 namespace Cr8\JoomlaHeadlessApi\HeadlessApi;
 
-require_once 'database.php';
+require_once __DIR__ . '/database.php';
 use OpenApi\Annotations as OA;
 
 /**
@@ -38,11 +38,6 @@ class MenuAPI {
 
         return $menuItems;
     }
-}
-
-if ($_SERVER['REQUEST_METHOD'] === 'GET' && isset($_GET['menutype'])) {
-    $api = new MenuAPI();
-    echo json_encode($api->getMenuItems($_GET['menutype']));
 }
 
 /**

--- a/src/HeadlessApi/database.php
+++ b/src/HeadlessApi/database.php
@@ -1,5 +1,5 @@
 <?php
-require_once '../configuration.php';
+require_once __DIR__ . '/../configuration.php';
 
 class Database {
     private $connection;

--- a/src/hapi/article/index.php
+++ b/src/hapi/article/index.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+use Cr8\JoomlaHeadlessApi\HeadlessApi\ArticleAPI;
+
+require_once __DIR__ . '/../../HeadlessApi/ArticleAPI.php';
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'GET') {
+    http_response_code(405);
+    echo json_encode(['error' => 'Method Not Allowed']);
+    exit;
+}
+
+$api = new ArticleAPI();
+
+if (isset($_GET['category'])) {
+    $payload = $api->getArticlesByCategory($_GET['category']);
+} elseif (isset($_GET['id'])) {
+    $payload = $api->getArticlesById($_GET['id']);
+} elseif (isset($_GET['slug'])) {
+    $payload = $api->getArticlesBySlug($_GET['slug']);
+} else {
+    http_response_code(400);
+    echo json_encode(['error' => 'Missing query parameter. Provide category, id or slug.']);
+    exit;
+}
+
+$json = json_encode($payload);
+
+if ($json === false) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Failed to encode response as JSON.', 'details' => json_last_error_msg()]);
+    exit;
+}
+
+echo $json;

--- a/src/hapi/article/index.php
+++ b/src/hapi/article/index.php
@@ -23,7 +23,10 @@ if (isset($_GET['category'])) {
     $payload = $api->getArticlesBySlug($_GET['slug']);
 } else {
     http_response_code(400);
-    echo json_encode(['error' => 'Missing query parameter. Provide category, id or slug.']);
+    echo json_encode([
+        'error' => 'Missing query parameter.',
+        'details' => 'Provide category, id or slug.'
+    ]);
     exit;
 }
 

--- a/src/hapi/category/index.php
+++ b/src/hapi/category/index.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+use Cr8\JoomlaHeadlessApi\HeadlessApi\CategoryAPI;
+
+require_once __DIR__ . '/../../HeadlessApi/CategoryAPI.php';
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'GET') {
+    http_response_code(405);
+    echo json_encode(['error' => 'Method Not Allowed']);
+    exit;
+}
+
+$api = new CategoryAPI();
+$payload = $api->getCategories();
+
+$json = json_encode($payload, JSON_FORCE_OBJECT | JSON_PRETTY_PRINT);
+
+if ($json === false) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Failed to encode response as JSON.', 'details' => json_last_error_msg()]);
+    exit;
+}
+
+echo $json;

--- a/src/hapi/menu/index.php
+++ b/src/hapi/menu/index.php
@@ -9,24 +9,24 @@ header('Content-Type: application/json');
 
 if ($_SERVER['REQUEST_METHOD'] !== 'GET') {
     http_response_code(405);
-    echo json_encode(['error' => 'Method Not Allowed']);
+    echo json_encode(['error' => 'Method Not Allowed'], JSON_FORCE_OBJECT | JSON_PRETTY_PRINT);
     exit;
 }
 
 if (!isset($_GET['menutype'])) {
     http_response_code(400);
-    echo json_encode(['error' => 'Missing query parameter.', 'details' => 'Provide menutype.']);
+    echo json_encode(['error' => 'Missing query parameter.', 'details' => 'Provide menutype.'], JSON_FORCE_OBJECT | JSON_PRETTY_PRINT);
     exit;
 }
 
 $api = new MenuAPI();
 $payload = $api->getMenuItems($_GET['menutype']);
 
-$json = json_encode($payload);
+$json = json_encode($payload, JSON_FORCE_OBJECT | JSON_PRETTY_PRINT);
 
 if ($json === false) {
     http_response_code(500);
-    echo json_encode(['error' => 'Failed to encode response as JSON.', 'details' => json_last_error_msg()]);
+    echo json_encode(['error' => 'Failed to encode response as JSON.', 'details' => json_last_error_msg()], JSON_FORCE_OBJECT | JSON_PRETTY_PRINT);
     exit;
 }
 

--- a/src/hapi/menu/index.php
+++ b/src/hapi/menu/index.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+use Cr8\JoomlaHeadlessApi\HeadlessApi\MenuAPI;
+
+require_once __DIR__ . '/../../HeadlessApi/MenuAPI.php';
+
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'GET') {
+    http_response_code(405);
+    echo json_encode(['error' => 'Method Not Allowed']);
+    exit;
+}
+
+if (!isset($_GET['menutype'])) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Missing query parameter.', 'details' => 'Provide menutype.']);
+    exit;
+}
+
+$api = new MenuAPI();
+$payload = $api->getMenuItems($_GET['menutype']);
+
+$json = json_encode($payload);
+
+if ($json === false) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Failed to encode response as JSON.', 'details' => json_last_error_msg()]);
+    exit;
+}
+
+echo $json;


### PR DESCRIPTION
## Summary
- add dedicated `hapi` resource folders for articles, categories, and menus with index entrypoints
- route the new entrypoints through the existing API classes and standardise JSON error handling
- update API classes to use robust relative includes and leave only business logic

## Testing
- `php -l src/hapi/article/index.php`
- `php -l src/hapi/category/index.php`
- `php -l src/hapi/menu/index.php`
- `composer install` *(fails: requires GitHub credentials for package downloads)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b4f38d7c832db0ba0985a2ddd6aa